### PR TITLE
Fix incorrect priority settings #73

### DIFF
--- a/firmware/project_competition_wolfiemouse/control_loop_thread_driver.c
+++ b/firmware/project_competition_wolfiemouse/control_loop_thread_driver.c
@@ -28,9 +28,9 @@ pid_value_t pid_tran_forwarding_value = {
 };
 
 pid_value_t pid_rot_forwarding_value = {
-            .kp = 3,
+            .kp = 8,
             .ki = 0,
-            .kd = 400
+            .kd = 1000
 };
 
 pid_value_t pid_tran_rotating_value = {

--- a/firmware/project_competition_wolfiemouse/control_loop_thread_driver.c
+++ b/firmware/project_competition_wolfiemouse/control_loop_thread_driver.c
@@ -266,7 +266,7 @@ void loop_move_forward (struct mouse_data_pid *pid,
     target_wheel_dir.right = WHEEL_FORWARD;
 
     while (1) {
-        control_loop_thread_wait_until_1ms();
+        control_loop_thread_wait_1ms();
         update_steps_and_speed(&total_step, &speed);
         update_range(range);
 
@@ -355,7 +355,7 @@ void loop_pivot (struct mouse_data_pid *pid,
     target_wheel_dir.right = (target_step_right > 0) ? WHEEL_FORWARD : WHEEL_BACKWARD;
 
     while (1) {
-        control_loop_thread_wait_until_1ms();
+        control_loop_thread_wait_1ms();
         update_steps_and_speed(&total_step, &speed);
 
         /* Calculate PID */
@@ -420,7 +420,7 @@ void loop_smooth_trun (struct mouse_data_pid *pid,
     target_wheel_dir.right = WHEEL_FORWARD;
 
     while (1) {
-        control_loop_thread_wait_until_1ms();
+        control_loop_thread_wait_1ms();
         update_steps_and_speed(&total_step, &speed);
 
         /* Calculate PID */

--- a/firmware/project_competition_wolfiemouse/control_loop_thread_driver.c
+++ b/firmware/project_competition_wolfiemouse/control_loop_thread_driver.c
@@ -308,7 +308,7 @@ void loop_move_forward (struct mouse_data_pid *pid,
         motor_speed_permyriad(CH_RIGHT, outputT - outputR);
         motor_start(CH_BOTH);
 
-        // logger_log(pid, range, &total_step, &speed, outputT, outputR);
+        logger_log(pid, range, &total_step, &speed, outputT, outputR);
 
         if (check_escape_condition(pid, &total_step, &target_step,
                                    &target_wheel_dir)) {
@@ -372,7 +372,7 @@ void loop_pivot (struct mouse_data_pid *pid,
         motor_speed_permyriad(CH_RIGHT, outputT - outputR);
         motor_start(CH_BOTH);
 
-        // logger_log(pid, NULL, &total_step, &speed, outputT, outputR);
+        logger_log(pid, NULL, &total_step, &speed, outputT, outputR);
 
         if (check_escape_condition(pid, &total_step, &target_step,
                                     &target_wheel_dir)) {
@@ -437,7 +437,7 @@ void loop_smooth_trun (struct mouse_data_pid *pid,
         motor_speed_permyriad(CH_RIGHT, outputT - outputR);
         motor_start(CH_BOTH);
 
-        // logger_log(pid, NULL, &total_step, &speed, outputT, outputR);
+        logger_log(pid, NULL, &total_step, &speed, outputT, outputR);
 
         if (check_escape_condition(pid, &total_step, &target_step,
                                     &target_wheel_dir)) {

--- a/firmware/project_competition_wolfiemouse/main.cc
+++ b/firmware/project_competition_wolfiemouse/main.cc
@@ -214,6 +214,7 @@ static void _maze_solver_run(void (*wait_func)(MouseController *mouse))
                 goto end;
             }
         }
+        taskYIELD();
     }
 
 end:
@@ -225,10 +226,14 @@ static void _wait_for_button(MouseController *mouse)
     char buffer[80];
     char *keyinput = buffer;
     char key;
+
+    // Stop the mouse completely and print the maze and the information.
+    cmd_low_pid_reset_and_stop(NULL);
     mouse->printMaze();
     puts("please input a command");
     puts("n:next, q: save and restart, p: print stack");
     fflush(stdout);
+
     while (true) {
         if (!terminal_gets(keyinput)) {
             // TODO: why it gets error? It seems to get error and sucess back and forth.
@@ -246,6 +251,7 @@ static void _wait_for_button(MouseController *mouse)
         } else {
             continue;
         }
+        taskYIELD();
     }
     return;
 save_and_exit:

--- a/firmware/project_simulation_nucleo64/main.cc
+++ b/firmware/project_simulation_nucleo64/main.cc
@@ -107,10 +107,12 @@ static void task_1_mouse_simulation ()
 
 void task_2_logger_test ()
 {
+    vTaskPrioritySet(NULL, configMAX_PRIORITIES - 1);
     for(int i = 0; i < 1000; i++) {
         logger_log(NULL, NULL, NULL, NULL, 100, 1200);
         vTaskDelay(1);
     }
+    vTaskPrioritySet(NULL, configMAX_PRIORITIES - 3);
 }
 
 /*******************************************************************************
@@ -266,7 +268,7 @@ int main(void)
             "Blinky",               /* Text name for the task. This is to facilitate debugging only. It is not used in the scheduler */
             configMINIMAL_STACK_SIZE, /* Stack depth in words */
             NULL,                   /* Pointer to a task parameters */
-            configMAX_PRIORITIES - 3,                      /* The task priority */
+            0,                      /* The task priority */
             &task_blinky_handler);  /* Pointer of its task handler, if you don't want to use, you can leave it NULL */
 
     if (result != pdPASS) {
@@ -278,7 +280,7 @@ int main(void)
             "Main",
             configMINIMAL_STACK_SIZE+15500,
             NULL,
-            configMAX_PRIORITIES,
+            configMAX_PRIORITIES - 3,
             &task_main_handler);
     if (result != pdPASS) {
         terminal_puts("Creating main task failed!!");

--- a/firmware/src/board/wolfiemouse/FreeRTOSConfig.h
+++ b/firmware/src/board/wolfiemouse/FreeRTOSConfig.h
@@ -100,6 +100,7 @@
  * configUSE_TICK_HOOK
  * configCHECK_FOR_STACK_OVERFLOW 2
  */
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION 1
 #define configUSE_PREEMPTION			1
 #define configUSE_IDLE_HOOK				0
 #define configUSE_TICK_HOOK				0

--- a/firmware/src/board/wolfiemouse/control_loop_thread.c
+++ b/firmware/src/board/wolfiemouse/control_loop_thread.c
@@ -110,7 +110,7 @@ void control_loop_thread_init(void)
             "Cnrt",
             configMINIMAL_STACK_SIZE+2000,
             NULL,
-            configMAX_PRIORITIES,
+            configMAX_PRIORITIES - 1,
             &control_loop_handler);
     if (result != pdPASS) {
         KB_DEBUG_ERROR("Creating motion task failed!!");

--- a/firmware/src/board/wolfiemouse/control_loop_thread.c
+++ b/firmware/src/board/wolfiemouse/control_loop_thread.c
@@ -138,7 +138,7 @@ static void control_loop(void *pvParameters)
     vTaskDelete(NULL);
 }
 
-void control_loop_thread_wait_until_1ms(void)
+void control_loop_thread_wait_1ms(void)
 {
     vTaskDelay(1);
 }

--- a/firmware/src/module/control_loop_thread.h
+++ b/firmware/src/module/control_loop_thread.h
@@ -17,7 +17,7 @@ extern "C" {
 #endif
 
 void control_loop_thread_init(void);
-void control_loop_thread_wait_until_1ms(void);
+void control_loop_thread_wait_1ms(void);
 QueueHandle_t control_loop_thread_cmd_queue(void);
 SemaphoreHandle_t control_loop_thread_get_cmd_semphr(void);
 

--- a/firmware/src/module/logger_thread.c
+++ b/firmware/src/module/logger_thread.c
@@ -101,7 +101,6 @@ static void writer_loop(void *pvParameters)
     static struct data *data;
     static uint32_t start_time = 0;
 
-    xSemaphoreGive(notify_semphr);
     while (1) {
         // Writer ready
         xSemaphoreGive(notify_semphr);

--- a/firmware/src/module/logger_thread.c
+++ b/firmware/src/module/logger_thread.c
@@ -57,7 +57,7 @@ void logger_thread_init(void)
             "logger",
             configMINIMAL_STACK_SIZE,
             NULL,
-            configMAX_PRIORITIES - 1,
+            configMAX_PRIORITIES - 3,
             &thread_handler);
     if (result != pdPASS) {
         terminal_puts("Creating logger task failed!!");
@@ -75,10 +75,10 @@ int logger_log (
     static struct data data;
     struct data *ptr;
 
-    if (pdTRUE != xSemaphoreTake(notify_semphr, 0)) {
-        // Writer is busy
+    if (!uxSemaphoreGetCount(notify_semphr)) {
         return 1;
     }
+    xSemaphoreTake(notify_semphr, 0);
 
     // Copy data and send
     data = (struct data){

--- a/firmware/src/system/interrupt_handler.c
+++ b/firmware/src/system/interrupt_handler.c
@@ -48,13 +48,9 @@ void SVC_Handler (void)
     extern void xPortSysTickHandler(void);
 #endif
 
-extern void SysTick_hook(void); // Can be found in hooks.c
-
 void SysTick_Handler (void)
 {
 	tick_inc_ms();
-    SysTick_hook();
-
 #ifdef KB_USE_FREERTOS
 	// FreeRTOS Tick handler
     if (xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED) {

--- a/tools/plot.py
+++ b/tools/plot.py
@@ -22,23 +22,60 @@ long_labels = ["T_target", "R_target",
                "time"]
 df = df[short_labels]
 df.columns = long_labels
+df["travel_distance"] = (df["Left_travel"] + df["Right_travel"]) / 2
 
 print(df.tail())
 
 # plot
-fig, axes = plt.subplots(nrows=3, ncols=1)
-pids = df[["T_target", "R_target",
-           "T_output", "R_output",
-           "time"]]
-speed = df[["Left_speed", "Right_speed",
-            "Left_travel", "Right_travel",
-            "time"]]
-range_sensor = df[["Left_distance", "Right_distance", "Front_distance",
-                   "Left_travel", "Right_travel",
-                   "time"]]
+fig, axes = plt.subplots(nrows=3, ncols=2)
 
-pids.plot(x="time", ax=axes[0]) #, ylim=(0,speeds["T_setpoint"].max()+10), 
-speed.plot(x="time", ax=axes[1]) #, ylim=(-10,pwms["Output_Left"].max()), 
-range_sensor.plot(x="time", ax=axes[2]) #, ylim=(-10,pwms["Output_Left"].max()), 
-# df.plot(secondary_y=["Output_Left", "Output_Right"], mark_right=False)
+# Plot data over time
+df.plot(
+    y=["T_target", "R_target",
+        "T_output", "R_output"],
+    x="time",
+    ax=axes[0, 0],
+    # ylim=(0,speeds["T_setpoint"].max()+10),
+    )
+df.plot(
+    y=["Left_speed", "Right_speed",
+        "Left_travel", "Right_travel"],
+    x="time",
+    ax=axes[1, 0],
+    # ylim=(-10,pwms["Output_Left"].max()),
+    )
+df.plot(
+    y=["Left_distance",
+        "Right_distance", "Front_distance"],
+    x="time",
+    ax=axes[2, 0],
+    # ylim=(-10,pwms["Output_Left"].max())
+    )
+
+# Plot data over distance
+df.plot(
+    y=["T_target", "R_target",
+        "T_output", "R_output"],
+    x="travel_distance",
+    ax=axes[0, 1],
+    # ylim=(0,speeds["T_setpoint"].max()+10),
+    )
+df.plot(
+    y=["Left_speed", "Right_speed",
+        "Left_travel", "Right_travel"],
+    x="travel_distance",
+    ax=axes[1, 1],
+    # ylim=(-10,pwms["Output_Left"].max()),
+    )
+df.plot(
+    y=["Left_distance",
+        "Right_distance", "Front_distance"],
+    x="travel_distance",
+    ax=axes[2, 1],
+    # ylim=(-10,pwms["Output_Left"].max())
+    )
+
+
+
+
 plt.show()


### PR DESCRIPTION
The problem with higher priority thread being blocked by lower priority is caused by wrong thread priority settings.
Some thread have the priority of `configMAX_PRIORITIES`, which is invalid. The highest possible priority is `configMAX_PRIORITIES - 1`.
Also I set the logger thread to the lowest priority among "normal" threads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbumsik/wolfiemouse/74)
<!-- Reviewable:end -->
